### PR TITLE
Embed upload template url as trusted to prevent errors with s3

### DIFF
--- a/osgeo_importer/static/osgeo_importer/importer.js
+++ b/osgeo_importer/static/osgeo_importer/importer.js
@@ -358,12 +358,12 @@
     })
 
   .directive('upload',
-      function($http, UploadedData) {
+      function($http, UploadedData, $sce) {
         return {
           restrict: 'E',
           replace: true,
           templateUrl: function(elem,attrs) {
-           return attrs.templateUrl || '/static/osgeo_importer/partials/upload.html'
+           return $sce.trustAsResourceUrl(attrs.templateUrl || '/static/osgeo_importer/partials/upload.html');
           },
           scope: {
               upload: '=uploadObject',


### PR DESCRIPTION
A bug seems to occur only with s3 links that gives an `Error: [$sce:insecurl] Blocked loading resource from url not allowed by $sceDelegate policy.` Oddly it occurs even if you change the configurations to allow the URL specifically.