### PR TITLE
Multifile upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-
+src/
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN pip install -e .
 
 ADD downloads/importer-test-files /django-osgeo-uploader/importer-test-files
 
-CMD /bin/bash -c "service postgresql start; scripts/before_script.sh; /bin/bash"
+CMD /bin/bash -c "service postgresql start;  scripts/before_script.sh; /bin/bash"
 
 EXPOSE 80
 EXPOSE 8080

--- a/osgeo_importer/handlers/__init__.py
+++ b/osgeo_importer/handlers/__init__.py
@@ -11,7 +11,8 @@ DEFAULT_IMPORT_HANDLERS = ['osgeo_importer.handlers.FieldConverterHandler',
                            'osgeo_importer.handlers.geoserver.GeoServerBoundsHandler',
                            'osgeo_importer.handlers.geoserver.GeoServerStyleHandler',
                            'osgeo_importer.handlers.geoserver.GenericSLDHandler',
-                           'osgeo_importer.handlers.geonode.GeoNodePublishHandler']
+                           'osgeo_importer.handlers.geonode.GeoNodePublishHandler',
+                           'osgeo_importer.handlers.geonode.GeoNodeMetadataHandler']
 
 IMPORT_HANDLERS = getattr(settings, 'IMPORT_HANDLERS', DEFAULT_IMPORT_HANDLERS)
 

--- a/osgeo_importer/handlers/__init__.py
+++ b/osgeo_importer/handlers/__init__.py
@@ -9,6 +9,7 @@ DEFAULT_IMPORT_HANDLERS = ['osgeo_importer.handlers.FieldConverterHandler',
                            'osgeo_importer.handlers.geoserver.GeoServerTimeHandler',
                            'osgeo_importer.handlers.geoserver.GeoWebCacheHandler',
                            'osgeo_importer.handlers.geoserver.GeoServerBoundsHandler',
+                           'osgeo_importer.handlers.geoserver.GeoServerStyleHandler',
                            'osgeo_importer.handlers.geoserver.GenericSLDHandler',
                            'osgeo_importer.handlers.geonode.GeoNodePublishHandler']
 

--- a/osgeo_importer/handlers/geonode/__init__.py
+++ b/osgeo_importer/handlers/geonode/__init__.py
@@ -8,6 +8,9 @@ from django import db
 import os
 import re
 
+import logging
+log = logging.getLogger(__name__)
+
 User = get_user_model()
 
 
@@ -63,7 +66,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
 
         if self.importer.upload_file and results['layers'][0]['status'] == 'created':
             matched_layer = Layer.objects.get(name=results['layers'][0]['name'])
-            upload_layer = UploadLayer.objects.get(upload=self.importer.upload_file.upload,
+            upload_layer = UploadLayer.objects.get(upload_file=self.importer.upload_file,
                                                    index=layer_config.get('index'))
             upload_layer.layer = matched_layer
             upload_layer.save()

--- a/osgeo_importer/handlers/geonode/__init__.py
+++ b/osgeo_importer/handlers/geonode/__init__.py
@@ -3,7 +3,10 @@ from osgeo_importer.models import UploadLayer
 from osgeo_importer.handlers import ImportHandlerMixin
 from osgeo_importer.handlers import ensure_can_run
 from geonode.geoserver.helpers import gs_slurp
+from geonode.layers.metadata import set_metadata
+from geonode.layers.utils import resolve_regions
 from django.contrib.auth import get_user_model
+from django.core.files.storage import FileSystemStorage
 from django import db
 import os
 import re
@@ -12,6 +15,7 @@ import logging
 log = logging.getLogger(__name__)
 
 User = get_user_model()
+MEDIA_ROOT = FileSystemStorage().location
 
 
 class GeoNodePublishHandler(ImportHandlerMixin):
@@ -72,3 +76,56 @@ class GeoNodePublishHandler(ImportHandlerMixin):
             upload_layer.save()
 
         return results
+
+
+class GeoNodeMetadataHandler(ImportHandlerMixin):
+    """
+    Import uploaded XML
+    """
+
+    def can_run(self, layer, layer_config, *args, **kwargs):
+        """
+        Only run this handler if the layer is found in Geoserver and the layer's style is the generic style.
+        """
+        if not layer_config.get('metadata', None):
+            log.debug('Could not find any metadata xml in config %s', layer_config)
+            return False
+
+        return True
+
+    @ensure_can_run
+    def handle(self, layer, layer_config, *args, **kwargs):
+        """
+        Update metadata from xml
+        """
+        geonode_layer = Layer.objects.get(name=layer)
+        path = "%s/uploads/%s" % (MEDIA_ROOT, layer_config.get('upload_id'))
+        xmlfile = "%s/%s" % (path, layer_config.get('metadata'))
+        geonode_layer.metadata_uploaded = True
+        identifier, vals, regions, keywords = set_metadata(open(xmlfile).read())
+
+        regions_resolved, regions_unresolved = resolve_regions(regions)
+        keywords.extend(regions_unresolved)
+
+        # set regions
+        regions_resolved = list(set(regions_resolved))
+        if regions:
+            if len(regions) > 0:
+                geonode_layer.regions.add(*regions_resolved)
+
+        # set taggit keywords
+        keywords = list(set(keywords))
+        geonode_layer.keywords.add(*keywords)
+
+        # set model properties
+        for (key, value) in vals.items():
+            if key == "spatial_representation_type":
+                # value = SpatialRepresentationType.objects.get(identifier=value)
+                pass
+            else:
+                log.debug('Adding Metadata %s %s %s', geonode_layer, key, value)
+                setattr(geonode_layer, key, value)
+
+        geonode_layer.save()
+
+        return geonode_layer

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -5,9 +5,13 @@ import requests
 from decimal import Decimal, InvalidOperation
 from django import db
 from osgeo_importer.handlers import ImportHandlerMixin, GetModifiedFieldsMixin, ensure_can_run
-from geoserver.catalog import FailedRequestError
+from geoserver.catalog import FailedRequestError, ConflictingDataError
 from geonode.geoserver.helpers import gs_catalog
 from geoserver.support import DimensionInfo
+from osgeo_importer.utils import CheckFile, increment_filename
+from osgeo_importer.models import UploadLayer
+import logging
+log = logging.getLogger(__name__)
 
 
 def configure_time(resource, name='time', enabled=True, presentation='LIST', resolution=None, units=None,
@@ -142,8 +146,8 @@ class GeoserverPublishHandler(GeoserverHandlerMixin):
         if getattr(store, 'type', '').lower() == 'geogig':
             self.geogig_handler(store, layer, layer_config)
         ft = self.catalog.publish_featuretype(layer, self.get_or_create_datastore(layer_config),
-                                                layer_config.get('srs', self.srs))
-        ftjs = {'title':ft.title, 'projection':ft.projection, 'attributes':ft.attributes}
+                                              layer_config.get('srs', self.srs))
+        ftjs = {'title': ft.title, 'projection': ft.projection, 'attributes': ft.attributes}
         return ftjs
 
 
@@ -290,6 +294,72 @@ class GeoServerBoundsHandler(GeoserverHandlerMixin):
         except InvalidOperation:
             resource.latlon_bbox = ['-180', '180', '-90', '90', 'EPSG:4326']
             self.catalog.save(resource)
+
+
+class GeoServerStyleHandler(GeoserverHandlerMixin):
+    """
+    Adds styles to GeoServer Layer
+    """
+    catalog = gs_catalog
+    catalog._cache.clear()
+    workspace = 'geonode'
+
+    def can_run(self, layer, layer_config, *args, **kwargs):
+        """
+        Returns true if the configuration has enough information to run the handler.
+        """
+        if not any([layer_config.get('default_style', None), layer_config.get('styles', None)]):
+            log.debug('Could not find any styles in config %s',layer_config)
+            return False
+
+        return True
+
+    @ensure_can_run
+    def handle(self, layer, layer_config, *args, **kwargs):
+        """
+        Handler specific params:
+        "default_sld": SLD to load as default_sld
+        "slds": SLDS to add to layer
+        """
+        log.debug(layer,layer_config)
+        lyr = self.catalog.get_layer(layer)
+        uplyr = UploadLayer.objects.get(name=lyr.name)
+        path = os.path.dirname(uplyr.upload_file.file.path)
+        log.debug(path)
+        default_sld = layer_config.get('default_style', None)
+        slds = layer_config.get('styles', None)
+        all_slds=[]
+        if default_sld is not None:
+            slds.append(default_sld)
+
+        all_slds = list(set(slds))
+        all_slds = [CheckFile(x) for x in all_slds if x is not None]
+
+        styles = []
+        default_style = None
+        for sld in all_slds:
+            with open("%s/%s"%(path,sld.name)) as s:
+                n=0
+                sldname = sld.root
+                while True:
+                    n += 1
+                    try:
+                        self.catalog.create_style(sldname, s.read(), overwrite=False, workspace=self.workspace)
+                    except ConflictingDataError as e:
+                        sldname = increment_filename(sldname)
+                    if n>= 100:
+                        break
+
+                style = self.catalog.get_style(sld.root, workspace=self.workspace)
+                if sld.name == default_sld:
+                    default_style = style
+                styles.append(style)
+
+        lyr.styles = list(set(lyr.styles + styles))
+        if default_style is not None:
+            lyr.default_style = default_style
+        self.catalog.save(lyr)
+        return {'default_style': default_style.filename}
 
 
 class GenericSLDHandler(GeoserverHandlerMixin):

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -141,9 +141,10 @@ class GeoserverPublishHandler(GeoserverHandlerMixin):
 
         if getattr(store, 'type', '').lower() == 'geogig':
             self.geogig_handler(store, layer, layer_config)
-
-        return self.catalog.publish_featuretype(layer, self.get_or_create_datastore(layer_config),
+        ft = self.catalog.publish_featuretype(layer, self.get_or_create_datastore(layer_config),
                                                 layer_config.get('srs', self.srs))
+        ftjs = {'title':ft.title, 'projection':ft.projection, 'attributes':ft.attributes}
+        return ftjs
 
 
 class GeoserverPublishCoverageHandler(GeoserverHandlerMixin):

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -8,12 +8,18 @@ from .utils import FileTypeNotAllowed, GdalErrorHandler, load_handler, launder, 
 from .handlers import IMPORT_HANDLERS
 from django.conf import settings
 from django import db
+from django.core.files.storage import FileSystemStorage
 
 ogr.UseExceptions()
 
 
 OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
-RASTER_FILES = getattr(settings, 'RASTER_FILES', '/tmp')
+MEDIA_ROOT = FileSystemStorage().location
+RASTER_FILES = '%s/rasterfiles' % MEDIA_ROOT
+try:
+    os.makedirs(RASTER_FILES)
+except:
+    pass
 
 
 class Import(object):

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -174,11 +174,33 @@ class UploadedData(models.Model):
         return 'Upload [%s] %s, %s' % (self.id, self.name, self.user)
 
 
+class UploadFile(models.Model):
+    upload = models.ForeignKey(UploadedData, null=True, blank=True)
+    file = models.FileField(upload_to="uploads", validators=[validate_file_extension, validate_inspector_can_read])
+    slug = models.SlugField(max_length=250, blank=True)
+
+    def __unicode__(self):
+        return self.slug
+
+    @property
+    def name(self):
+        return os.path.basename(self.file.path)
+
+    def save(self, *args, **kwargs):
+        self.slug = self.file.name
+        super(UploadFile, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        self.file.delete(False)
+        super(UploadFile, self).delete(*args, **kwargs)
+
+
 class UploadLayer(models.Model):
     """
     Layers stored in an uploaded data set.
     """
     upload = models.ForeignKey(UploadedData, null=True, blank=True)
+    upload_file = models.ForeignKey(UploadFile, null=True, blank=True)
     index = models.IntegerField(default=0)
     name = models.CharField(max_length=64, null=True)
     fields = JSONField(null=True)

--- a/osgeo_importer/tasks.py
+++ b/osgeo_importer/tasks.py
@@ -2,8 +2,10 @@ import os
 import shutil
 from .models import UploadFile
 from celery.task import task
+from .importers import OSGEO_IMPORTER
+from .utils import import_string
 
-from .views import OSGEO_IMPORTER
+OSGEO_IMPORTER = import_string(OSGEO_IMPORTER)
 
 
 @task

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -204,7 +204,7 @@ class UploaderTests(MapStoryTestMixin):
 
     def test_upload_with_slds(self):
         """
-        Tests Uploading Multiple Files
+        Tests Uploading sld
         """
         upload = self.generic_api_upload(
             ['boxes_with_date.zip',
@@ -223,6 +223,23 @@ class UploaderTests(MapStoryTestMixin):
         self.cat._cache.clear()
         self.assertEqual('boxes.sld',default_style.filename)
         self.assertEqual('boxes1.sld',gslayer.styles[1].filename)
+
+    def test_upload_with_metadata(self):
+        """
+        Tests Uploading metadata
+        """
+        upload = self.generic_api_upload(
+            ['boxes_with_date.zip',
+             'samplemetadata.xml',],
+              [{'upload_file_name': 'boxes_with_date.shp',
+               'config': [{'index': 0, 'metadata': 'samplemetadata.xml'}]}
+               ]
+        )
+        self.assertEqual(5, upload['count'])
+        layerid = upload['uploaded'][0]['pk'];
+        layer = Layer.objects.get(pk=layerid)
+        self.assertEqual(layer.language, 'eng')
+        self.assertEqual(layer.title, 'Old_Americas_LSIB_Polygons_Detailed_2013Mar')
 
     def test_raster(self):
         """

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -222,7 +222,7 @@ class UploaderTests(MapStoryTestMixin):
         default_style = gslayer.default_style
         self.cat._cache.clear()
         self.assertEqual('boxes.sld',default_style.filename)
-        #self.assertEqual('boxes1.sld',gslayer.styles[1].filename)
+        ##self.assertEqual('boxes1.sld',gslayer.styles[1].filename)
 
     def test_upload_with_metadata(self):
         """

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -222,7 +222,7 @@ class UploaderTests(MapStoryTestMixin):
         default_style = gslayer.default_style
         self.cat._cache.clear()
         self.assertEqual('boxes.sld',default_style.filename)
-        self.assertEqual('boxes1.sld',gslayer.styles[1].filename)
+        #self.assertEqual('boxes1.sld',gslayer.styles[1].filename)
 
     def test_upload_with_metadata(self):
         """

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -145,8 +145,6 @@ class UploaderTests(MapStoryTestMixin):
         # Clean up file handles
         for file, handle in handles.items():
             handle.close()
-
-        print response.content
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
@@ -203,6 +201,28 @@ class UploaderTests(MapStoryTestMixin):
                ]
         )
         self.assertEqual(9, upload['count'])
+
+    def test_upload_with_slds(self):
+        """
+        Tests Uploading Multiple Files
+        """
+        upload = self.generic_api_upload(
+            ['boxes_with_date.zip',
+             'boxes.sld',
+             'boxes1.sld'],
+              [{'upload_file_name': 'boxes_with_date.shp',
+               'config': [{'index': 0, 'default_style': 'boxes.sld',
+                           'styles': ['boxes.sld', 'boxes1.sld']}]}
+               ]
+        )
+        self.assertEqual(6, upload['count'])
+        layerid = upload['uploaded'][0]['pk'];
+        layer = Layer.objects.get(pk=layerid)
+        gslayer = self.cat.get_layer(layer.name)
+        default_style = gslayer.default_style
+        self.cat._cache.clear()
+        self.assertEqual('boxes.sld',default_style.filename)
+        self.assertEqual('boxes1.sld',gslayer.styles[1].filename)
 
     def test_raster(self):
         """

--- a/osgeo_importer/urls.py
+++ b/osgeo_importer/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url, include
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from .views import FileAddView, UploadListView
+from .views import FileAddView, UploadListView, MultiUpload
 from tastypie.api import Api
 from .api import UploadedDataResource, UploadedLayerResource, UploadedFileResource  # noqa
 
@@ -15,6 +15,8 @@ importer_api.register(UploadedFileResource())
 
 urlpatterns = patterns("",
                        url(r'^uploads/new$', login_required(FileAddView.as_view()), name='uploads-new'),
+                       url(r'^uploads/new-multi-json$', login_required(MultiUpload.as_view(json=True)),
+                           name='uploads-multi-json'),
                        url(r'^uploads/new/json$', login_required(FileAddView.as_view(json=True)),
                            name='uploads-new-json'),
                        url(r'^uploads/?$', login_required(UploadListView.as_view()), name='uploads-list'),

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -319,3 +319,45 @@ def decode(s, encodings=('ascii', 'utf8', 'latin1')):
         except UnicodeDecodeError:
             pass
     return s.decode('ascii', 'ignore')
+
+
+class CheckFile(object):
+    def __init__(self, file=None):
+        self.RASTER_EXTENSIONS = getattr(
+            settings, 'OSGEO_IMPORTER_RASTER_EXTENSIONS', ['tif'])
+        self.VECTOR_EXTENSIONS = getattr(
+            settings, 'OSGEO_IMPORTER_VECTOR_EXTENSIONS', [
+                'gpx', 'geojson', 'json', 'zip', 'tar', 'kml', 'csv', 'shp'])
+        self.SUPPORT_EXTENSIONS = getattr(
+            settings, 'OSGEO_IMPORTER_SUPPORT_EXTENSIONS', [
+                'xml', 'sld', 'prj', 'dbf', 'shx'])
+        self.DATA_EXTENSIONS = self.RASTER_EXTENSIONS + self.VECTOR_EXTENSIONS
+        self.VALID_EXTENSIONS = self.DATA_EXTENSIONS + self.SUPPORT_EXTENSIONS
+        try:
+            self.name = file.name
+        except:
+            self.name = file
+        if self.name != '' and self.name is not None:
+            self.basename = os.path.basename(self.name)
+            self.dirname = os.path.dirname(self.name)
+            self.root = os.path.splitext(self.basename)[0]
+            self.ext = self.file_ext()
+            self.raster = self.validate_extension(self.RASTER_EXTENSIONS)
+            self.vector = self.validate_extension(self.VECTOR_EXTENSIONS)
+            self.support = self.validate_extension(self.SUPPORT_EXTENSIONS)
+            self.datafile = self.validate_extension(self.DATA_EXTENSIONS)
+            self.valid_extension = self.validate_extension(
+                self.VALID_EXTENSIONS)
+            if self.ext == 'zip':
+                self.zip = True
+            else:
+                self.zip = False
+
+    def file_ext(self):
+        return os.path.splitext(self.name.lower())[1].replace('.', '')
+
+    def validate_extension(self, extlist):
+        if self.ext in extlist:
+            return True
+        else:
+            return False

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -1,15 +1,24 @@
 import json
-from django.http import HttpResponse
-from django.views.generic import FormView, ListView, TemplateView
+import os
+import shutil
+from zipfile import ZipFile
+from django.http import HttpResponse, Http404
+from django.views.generic import View,FormView, ListView, TemplateView
 from django.core.urlresolvers import reverse_lazy
+from django.core.files.storage import FileSystemStorage
 from .forms import UploadFileForm
-from .models import UploadedData, UploadLayer, DEFAULT_LAYER_CONFIGURATION
+from .models import UploadedData, UploadLayer,UploadFile, DEFAULT_LAYER_CONFIGURATION
 from .importers import OSGEO_IMPORTER
 from .inspectors import OSGEO_INSPECTOR
-from .utils import import_string
+from .utils import import_string, CheckFile
+
+import logging
+log = logging.getLogger(__name__)
 
 OSGEO_INSPECTOR = import_string(OSGEO_INSPECTOR)
 OSGEO_IMPORTER = import_string(OSGEO_IMPORTER)
+
+from .tasks import import_object
 
 
 class JSONResponseMixin(object):
@@ -115,3 +124,140 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
             return self.render_to_json_response(context, **response_kwargs)
 
         return super(FileAddView, self).render_to_response(context, **response_kwargs)
+
+
+def configure_layers(configs, upload_id=None):
+    log.debug(configs)
+    log.debug(len(configs))
+    log.debug(type(configs))
+    if isinstance(configs, type({})):
+        configs = [configs]
+    complete = []
+    for config in configs:
+        log.debug(config)
+        upload_id = config.get('upload_id', upload_id)
+        file_id = config.get('upload_file_id')
+        upload_file_name = config.get('upload_file_name')
+        if file_id is None and upload_id is not None and upload_file_name is not None:
+            try:
+                u = UploadFile.objects.filter(upload_id=upload_id)
+                for uf in u:
+                    log.debug(uf.name)
+                    if uf.name == upload_file_name:
+                        file_id = uf.pk
+                        break
+            except:
+                log.exception('Cannot Determine File ID')
+                continue
+        cfg = config.get('config')
+        log.debug(cfg)
+        log.debug('upfile id %s', file_id)
+        if cfg is not None and file_id is not None:
+            lyrs = import_object(file_id, cfg)
+            log.debug('lyrs ---------- %s', lyrs)
+            for lyr in lyrs:
+                complete.append(lyr)
+
+    return complete
+
+
+class MultiUpload(View, ImportHelper, JSONResponseMixin):
+    json = False
+
+    def post(self, request):
+        log.debug("File List: %s", request.FILES.getlist('file'))
+        if request.FILES is not None:
+            upload = UploadedData.objects.create(user=request.user)
+            upload.save()
+            if upload.pk < 1:
+                return Http404
+            savedir = os.path.join(MEDIA_ROOT, 'uploads', str(upload.pk))
+            # remove any folders with this upload id
+            if os.path.exists(savedir):
+                shutil.rmtree(savedir)
+            os.mkdir(savedir)
+            log.debug('Saving Files to %s', savedir)
+            req_files = request.FILES.getlist('file')
+
+            # Get Zipfiles
+            zipfiles = [file for file in req_files if CheckFile(file).zip]
+            log.debug('Zipfiles: %s', zipfiles)
+            for z in zipfiles:
+                req_files.remove(z)
+                with ZipFile(z) as zip:
+                    for zipf in zip.namelist():
+                        log.debug(zipf)
+                        zipfc = CheckFile(zipf)
+                        log.debug(zipfc.valid_extension)
+                        if not zipfc.valid_extension:
+                            log.debug('ignoring %s', zipfc.name)
+                            continue
+                        with zip.open(zipfc.name) as f:
+                            with open(os.path.join(savedir, zipfc.name), 'wb') as outfile:
+                                log.debug('copying %s', zipfc.name)
+                                shutil.copyfileobj(f, outfile)
+            for file in req_files:
+                filec = CheckFile(file)
+                log.debug("File name: %s", filec.name)
+                log.debug("valid %s", filec.valid_extension)
+                if filec.valid_extension:
+                    with open(os.path.join(savedir, filec.name), 'w') as sf:
+                        sf.write(file.read())
+                else:
+                    log.debug('Skipping Unsupported File: %s', filec.name)
+            dirfiles = os.listdir(savedir)
+            log.debug('Files copied to %s, %s', savedir, dirfiles)
+            for dirfile in dirfiles:
+                dirfile = CheckFile(dirfile)
+                upfile = UploadFile(upload=upload)
+                upfile.file.name = os.path.join(
+                    'uploads', str(upload.pk), dirfile.basename)
+                upfile.save()
+
+                if dirfile.support:
+                    continue
+                description = self.get_fields(upfile.file.path)
+
+                for layer in description:
+                    configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()
+                    configuration_options.update({'index': layer.get('index')})
+                    upload.uploadlayer_set.add(
+                        UploadLayer(
+                            upload_file=upfile,
+                            name=layer.get('name'),
+                            fields=layer.get(
+                                'fields',
+                                {}),
+                            index=layer.get('index'),
+                            feature_count=layer.get('feature_count'),
+                            configuration_options=configuration_options))
+
+            upload.state = 'UPLOADED'
+            upload.complete = True
+            upload.save()
+
+        response = {}
+
+        try:
+            count = UploadFile.objects.filter(upload=upload).count()
+            uploaded = []
+            for uploadedfile in UploadFile.objects.filter(upload=upload):
+                uploaded.append({'pk': uploadedfile.pk,
+                                 'name': uploadedfile.name,
+                                 'ext': CheckFile(uploadedfile.name).ext})
+            response['state'] = upload.state
+            response['id'] = upload.id
+            response['count'] = count
+            response['uploaded'] = uploaded
+        except:
+            log.debug('No Layers Uploaded')
+
+        if request.POST.get('json') is not None:
+            log.debug('Processing JSON configuration')
+            config = json.loads(request.POST['json'])
+            complete_layers = configure_layers(config, upload_id=upload.pk)
+            response['layers'] = complete_layers
+
+        if self.json:
+            return self.render_to_json_response(response)
+        return HttpResponse('<html><body>Woohoo!</body></html>')

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -11,6 +11,7 @@ from .models import UploadedData, UploadLayer, UploadFile, DEFAULT_LAYER_CONFIGU
 from .importers import OSGEO_IMPORTER
 from .inspectors import OSGEO_INSPECTOR
 from .utils import import_string, CheckFile
+from .tasks import import_object
 
 import logging
 log = logging.getLogger(__name__)
@@ -18,8 +19,6 @@ log = logging.getLogger(__name__)
 OSGEO_INSPECTOR = import_string(OSGEO_INSPECTOR)
 OSGEO_IMPORTER = import_string(OSGEO_IMPORTER)
 MEDIA_ROOT = FileSystemStorage().location
-
-from .tasks import import_object
 
 
 class JSONResponseMixin(object):
@@ -44,7 +43,7 @@ class JSONResponseMixin(object):
         # to do much more complex handling to ensure that arbitrary
         # objects -- such as Django model instances or querysets
         # -- can be serialized as JSON.
-        return json.dumps(context, default=lambda x:None)
+        return json.dumps(context, default=lambda x: None)
 
 
 class JSONView(JSONResponseMixin, TemplateView):

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -151,6 +151,8 @@ def configure_layers(configs, upload_id=None):
                 log.exception('Cannot Determine File ID')
                 continue
         cfg = config.get('config')
+        cfg[0]['upload_id'] = upload_id
+        cfg[0]['upload_file_id'] = file_id
         log.debug(cfg)
         log.debug('upfile id %s', file_id)
         if cfg is not None and file_id is not None:
@@ -259,6 +261,4 @@ class MultiUpload(View, ImportHelper, JSONResponseMixin):
             complete_layers = configure_layers(config, upload_id=upload.pk)
             response['layers'] = complete_layers
 
-        if self.json:
-            return self.render_to_json_response(response)
-        return HttpResponse('<html><body>Woohoo!</body></html>')
+        return self.render_to_json_response(response)


### PR DESCRIPTION
This branch adds the ability to add multiple files at once. It will automatically unzip any first level zip files. It also allows uploading and configuring .sld styles and .xml metadata files. Examples of usage are included in the tests. 

There is no UI for adding the multiple files.