### PR TITLE
unpin tastypie; allow GeoNode to pull in its own deps

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,9 +4,6 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-AWS_ACCESS_KEY_ID=ENV['AWS_ACCESS_KEY_ID']
-AWS_SECRET_ACCESS_KEY=ENV['AWS_SECRET_ACCESS_KEY']
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "ubuntu/trusty"
@@ -15,8 +12,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # When explicitly defining a VM, the name used replaces the token 'default'.
   config.vm.define "django-osgeo-importer"
-  config.vm.provision "shell", path: "scripts/install.sh", env: {:AWS_ACCESS_KEY_ID => AWS_ACCESS_KEY_ID,
-  :AWS_SECRET_ACCESS_KEY=>AWS_SECRET_ACCESS_KEY, :GS_VERSION=> '2.8.x'}, args: "/vagrant"
+  config.vm.provision "shell", path: "scripts/install.sh", env: {:GS_VERSION=> '2.8.x'}, args: "/vagrant"
 
  config.vm.provision "shell", path: "scripts/before_script.sh", args: "/vagrant"
 

--- a/scripts/downloads.sh
+++ b/scripts/downloads.sh
@@ -9,5 +9,5 @@ wget -N https://s3.amazonaws.com/django-osgeo-importer/gdal-2.1.0-linux-bin.tar.
 
 pip install awscli
 sudo mkdir -p -m 777 importer-test-files
-aws s3 sync s3://mapstory-data/importer-test-files/ importer-test-files
+aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files
 popd

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,4 +51,4 @@ pip install --upgrade python-dateutil
 pip install flake8
 
 sudo mkdir -p -m 777 importer-test-files
-aws s3 sync s3://mapstory-data/importer-test-files/ importer-test-files
+aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Framework :: Django',
     ],
     install_requires=[
+        'numpy==1.11.0'
     ],
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Framework :: Django',
     ],
     install_requires=[
-        'django-tastypie==0.11.0',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
_pre-req: https://github.com/ProminentEdge/django-osgeo-importer/pull/18 -- rebased so Travis CI doesn't barf on lack of AWS keys_

Tastypie's version should be matched to the Django version in use to avoid incompatibility errors (i.e., Django 1.8 needs django-tastypie 1.12+). Since GeoNode already pulls in both a Django version and a corresponding tastypie version, we can skip this here.