### PR TITLE
GeoGig double-gzip's responses; Requests doesn't like it

### DIFF
--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from tastypie.fields import DictField, ListField, CharField, ToManyField, ForeignKey
 from django.contrib.auth import get_user_model
 from tastypie.constants import ALL, ALL_WITH_RELATIONS
@@ -12,6 +13,8 @@ from django.conf.urls import url
 from tastypie.bundle import Bundle
 from .tasks import import_object
 from tastypie.exceptions import ImmediateHttpResponse
+
+logger = logging.getLogger(__name__)
 
 
 class UserResource(ModelResource):

--- a/osgeo_importer/geonode_apis.py
+++ b/osgeo_importer/geonode_apis.py
@@ -21,7 +21,7 @@ class UploadedLayerResource(UploadedLayerResource):  # noqa
             if store.get('type', str).lower() == 'geogig':
                 store.setdefault('branch', 'master')
                 store.setdefault('create', 'true')
-                store.setdefault('name', '{0}-storylayers'.format(request.user.username))
+                store.setdefault('name', '{0}-layers'.format(request.user.username))
                 store['geogig_repository'] = os.path.join(ogc_server_settings.GEOGIG_DATASTORE_DIR,
                                                           store.get('name'))
 

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -107,29 +107,55 @@ class GeoserverPublishHandler(GeoserverHandlerMixin):
         return self.catalog.get_store(connection_string['name'])
 
     def geogig_handler(self, store, layer, layer_config):
+        request_headers = {'Accept-Encoding': 'identity'}
 
         repo = store.connection_parameters['geogig_repository']
         auth = (self.catalog.username, self.catalog.password)
         repo_url = self.catalog.service_url.replace('/rest', '/geogig/{0}/'.format(repo))
-        transaction = requests.get(repo_url + 'beginTransaction.json', auth=auth)
+        transaction_url = repo_url + 'beginTransaction.json'
+        transaction = requests.get(transaction_url, auth=auth,
+                                   headers=request_headers)
+        logger.debug("""response status_code {} \n
+                        response headers {} \n
+                        request headers {} \n
+                     """.format(
+                         transaction.status_code,
+                         transaction.headers,
+                         transaction.request.headers))
         transaction_id = transaction.json()['response']['Transaction']['ID']
         params = self.get_default_store()
         params['password'] = params['passwd']
         params['table'] = layer
         params['transactionId'] = transaction_id
 
-        import_command = requests.get(repo_url + 'postgis/import.json', params=params, auth=auth)
+        import_command = requests.get(
+            repo_url + 'postgis/import.json',
+            params=params,
+            auth=auth,
+            headers=request_headers)
         task = import_command.json()['task']
 
         status = 'NOT RUN'
         while status != 'FINISHED':
-            check_task = requests.get(task['href'], auth=auth)
+            check_task = requests.get(
+                task['href'],
+                auth=auth,
+                headers=request_headers)
             status = check_task.json()['task']['status']
 
-        if check_task.json()['task']['status'] == 'FINISHED':
-            requests.get(repo_url + 'add.json', params={'transactionId': transaction_id}, auth=auth)
-            requests.get(repo_url + 'commit.json', params={'transactionId': transaction_id}, auth=auth)
-            requests.get(repo_url + 'endTransaction.json', params={'transactionId': transaction_id}, auth=auth)
+        if status == 'FINISHED':
+            requests.get(repo_url + 'add.json',
+                         params={'transactionId': transaction_id},
+                         auth=auth,
+                         headers=request_headers)
+            requests.get(repo_url + 'commit.json',
+                         params={'transactionId': transaction_id},
+                         auth=auth,
+                         headers=request_headers)
+            requests.get(repo_url + 'endTransaction.json',
+                         params={'transactionId': transaction_id},
+                         auth=auth,
+                         headers=request_headers)
 
     @ensure_can_run
     def handle(self, layer, layer_config, *args, **kwargs):

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -1,5 +1,6 @@
 import re
 import os
+import logging
 import requests
 
 from decimal import Decimal, InvalidOperation
@@ -8,6 +9,8 @@ from osgeo_importer.handlers import ImportHandlerMixin, GetModifiedFieldsMixin, 
 from geoserver.catalog import FailedRequestError
 from geonode.geoserver.helpers import gs_catalog
 from geoserver.support import DimensionInfo
+
+logger = logging.getLogger(__name__)
 
 
 def configure_time(resource, name='time', enabled=True, presentation='LIST', resolution=None, units=None,

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -20,11 +20,12 @@
 
 import os
 import tempfile
+import logging
 
 from celery.result import AsyncResult
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.db import models
 from djcelery.models import TaskState
@@ -43,6 +44,8 @@ from .utils import sizeof_fmt, load_handler
 DEFAULT_LAYER_CONFIGURATION = {'configureTime': False,
                                'editable': True,
                                'convert_to_date': []}
+
+logger = logging.getLogger(__name__)
 
 
 def validate_file_extension(value):
@@ -220,8 +223,11 @@ class UploadLayer(models.Model):
         """
         if self.task_id:
             try:
-                return TaskState.objects.get(task_id=self.task_id).state
-            except:
+                state = TaskState.objects.get(task_id=self.task_id).state
+                return state
+            except ObjectDoesNotExist:
+                asyncres = AsyncResult(self.task_id)
+                logger.debug("Import task status: {}".format(asyncres.status))
                 return AsyncResult(self.task_id).status
         return 'UNKNOWN'
 

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -40,7 +40,7 @@ from .importers import OSGEO_IMPORTER
 from .utils import NoDataSourceFound
 from .utils import sizeof_fmt, load_handler
 
-DEFAULT_LAYER_CONFIGURATION = {'configureTime': True,
+DEFAULT_LAYER_CONFIGURATION = {'configureTime': False,
                                'editable': True,
                                'convert_to_date': []}
 

--- a/osgeo_importer/static/osgeo_importer/factories.js
+++ b/osgeo_importer/static/osgeo_importer/factories.js
@@ -1,7 +1,7 @@
 'use strict';
 
 (function() {
-    angular.module('mapstory.factories', ['ngResource'])
+    angular.module('osgeoImporter.factories', ['ngResource'])
 
     .factory('UploadedData', function ($resource) {
         return $resource('/importer-api/data/:id/', {}, {'query': {

--- a/osgeo_importer/static/osgeo_importer/importer.js
+++ b/osgeo_importer/static/osgeo_importer/importer.js
@@ -6,10 +6,10 @@
   var layerService_ = null;
   var q_ = null;
 
-  angular.module('mapstory.uploader', [
+  angular.module('osgeoImporter.uploader', [
       'ngResource',
       'ui.bootstrap',
-      'mapstory.factories',
+      'osgeoImporter.factories',
       'angularFileUpload',
       'ngCookies',
       'mgo-angular-wizard'

--- a/osgeo_importer/static/osgeo_importer/partials/upload.html
+++ b/osgeo_importer/static/osgeo_importer/partials/upload.html
@@ -24,7 +24,7 @@
 
                                 <div class="col-xs-10 col-sm-10 col-md-10 col-lg-10 col-xs-offset-1 col-sm-offset-1 col-md-offset-1 col-lg-offset-1 layer-in-upload" ng-repeat="layer in upload.layers">
                                     <div class="layer-upload-name"> {{layer.name}}
-                                        <span class="pull-right" ng-show="layer.geonode_layer.title"><span style="font-weight: 600">StoryLayer:</span> <a href="{{layer.geonode_layer.url}}" target="_self">{{layer.geonode_layer.title}}</a></span>
+                                        <span class="pull-right" ng-show="layer.geonode_layer.title"><span style="font-weight: 600">Layer:</span> <a href="{{layer.geonode_layer.url}}" target="_self">{{layer.geonode_layer.title}}</a></span>
                                     </div>
                                     <hr/>
                                     <div class="row">
@@ -51,8 +51,8 @@
                                         </div>
                                     </div>
                                     <div class="col-md-12 col-lg-12">
-                                        <span class="pull-right" ng-click="open(layer, staticUrl+'osgeo_importer/partials/uploadWizard.html', staticUrl + 'mapstory/img/mapstory-icon.png', staticUrl)" ng-controller="ImportController" style="cursor: pointer;padding-left: 15px; margin-right: -11px">
-                                            Create StoryLayer  <i class="fa fa-long-arrow-right"></i>
+                                        <span class="pull-right" ng-click="open(layer, 'static/'+'osgeo_importer/partials/uploadWizard.html', 'static/'+ 'geonode/img/logo.png', staticUrl)" ng-controller="ImportController" style="cursor: pointer;padding-left: 15px; margin-right: -11px">
+                                            Create Layer <i class="fa fa-long-arrow-right"></i>
                                         </span>
                                     </div>
 
@@ -61,7 +61,7 @@
                                         <div class="col-md-12 col-lg-12">
                                             <br/>
                                             <div class="form-group">
-                                                <label for="layerName" class="col-sm-3 col-xs-3 col-md-3 control-label">StoryLayer Name:</label>
+                                                <label for="layerName" class="col-sm-3 col-xs-3 col-md-3 control-label">Layer Name:</label>
                                                 <input id="layerName" type="text" class="col-md-5" ng-model="layer.configuration_options.name" placeholder="{{layer.name}}">
                                             </div>
                                             <div class="form-group">
@@ -90,9 +90,9 @@
                                             </div>
                                             <div class="col-xs-offset-2 col-sm-offset-2 col-md-offset-2 col-md-8 col-lg-8" style="padding: 10px; display: table-cell; text-align: center">
                                                 <span style="color:#FF4136;" ng-show="hasFailure()">This import has failed.  Adjust configuration above.</span>
-                                                <span style="color:#3D9970;" ng-show="successful()">The import has finished successfully. View the <a href="{{layer.geonode_layer.url}}" style="font-weight: 600">StoryLayer</a>.</span>
+                                                <span style="color:#3D9970;" ng-show="successful()">The import has finished successfully. View the <a href="{{layer.geonode_layer.url}}" style="font-weight: 600">Layer</a>.</span>
                                             </div>
-                                            <div class="btn btn-sm col-xs-offset-4 col-sm-offset-4 col-md-offset-4 col-md-3 btn-success import-button" ng-click="open(layer, staticUrl+'osgeo_importer/partials/uploadWizard.html', staticUrl+'mapstory/img/mapstory-icon.png', staticUrl)" ng-controller="ImportController" ng-class="{'disabled': !isValid()}">>>Import
+                                            <div class="btn btn-sm col-xs-offset-4 col-sm-offset-4 col-md-offset-4 col-md-3 btn-success import-button" ng-click="open(layer, 'static/'+'osgeo_importer/partials/uploadWizard.html', null, staticUrl)" ng-controller="ImportController" ng-class="{'disabled': !isValid()}">&gt;&gt;Import
                                                 <i class="fa" ng-class="{'fa-circle-o-notch fa-spin': processing(), 'fa-arrow-circle-right': !processing()}"></i>
                                             </div>
 

--- a/osgeo_importer/static/osgeo_importer/partials/uploadModal.html
+++ b/osgeo_importer/static/osgeo_importer/partials/uploadModal.html
@@ -1,6 +1,6 @@
 
 <div class="modal-header">
-    <h3 class="modal-title">Upload a StoryLayer <img class="import-wizard-icon" ng-src="{{modalImage}}"/></h3>
+    <h3 class="modal-title">Upload a Layer <img class="import-wizard-icon" ng-src="{{modalImage}}"/></h3>
 </div>
 <div class="modal-body row">
     <div class="col-sm-8 col-md-8 col-lg-8 col-md-offset-2" style="padding-top: 5px; padding-left: 2px;">

--- a/osgeo_importer/static/osgeo_importer/partials/uploadWizard.html
+++ b/osgeo_importer/static/osgeo_importer/partials/uploadWizard.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-        <h3 class="modal-title">{{appending() === true ? "Append data to StoryLayer" : "Create a StoryLayer"}}<img class="import-wizard-icon" ng-src="{{modalImage}}"/></h3>
+        <h3 class="modal-title">{{appending() === true ? "Append data to layer" : "Create a layer"}}<img class="import-wizard-icon" ng-src="{{modalImage}}"/></h3>
 </div>
 <div class="modal-body row">
     <div class="col-sm-12 col-md-12 col-lg-12 import-wizard-modal">
@@ -21,10 +21,10 @@
             <div class="col-sm-8 col-md-8 col-lg-8 col-md-offset-2" style="padding-top: 5px; padding-left: 2px;" ng-controller="UploaderController">
 
                 <h3 ng-show="appending() === false"><strong>Upload your data.</strong></h3>
-                <p ng-show="appending() === false ">MapStory accepts data in .csv, .geojson, .gpx, .kml,  .tif, and zipped shapefile formats. To upload a print map or raster image, first you need to georeference it with the MapStory Warper. By sharing your data in MapStory, you agree to our <a href="http://wiki.mapstory.org/wiki/Terms_of_Service" target="_blank">licensing and terms</a>.</p>
+                <p ng-show="appending() === false ">You can upload data in .csv, .geojson, .gpx, .kml,  .tif, and zipped shapefile formats.</p>
 
                 <h3 ng-show="appending()"><strong>Upload your feature edits.</strong></h3>
-                <p ng-show="appending()">Upload the blank file you downloaded earlier that now has your new feature edits added. Once your append is complete, you should see all of your new features added as edits to this StoryLayer.</p>
+                <p ng-show="appending()">Upload the blank file you downloaded earlier that now has your new feature edits added. Once your append is complete, you should see all of your new features added as edits to this layer.</p>
 
 
 
@@ -52,8 +52,7 @@
 
 
         <wz-step title="Name">
-            <h3><strong>Name your StoryLayer</strong></h3>
-            <p>Descriptive layer names make it easy for others to find your data.</p>
+            <h3><strong>Name your Layer</strong></h3>
             <form name="importOptionsForm" class="form-horizontal import-options-form">
                 <div class="form-group">
                     <input id="layerName" type="text" class=input-lg ng-model="layer.configuration_options.name">
@@ -66,9 +65,7 @@
         </wz-step>
 
         <wz-step title="Enable Time?" canexit="layer.configuration_options.configureTime || false">
-            <img class="import-wizard-image" ng-src="{{staticUrl}}mapstory/img/time.png"/>
-            <h3><strong>Confirm dataset has time attributes</strong></h3>
-            <p>All datasets uploaded to MapStory must contain time information. If the dataset contains only one timeslice, add a column indicating the timeslice. Learn more about Time Attributes.</p>
+            <h3><strong>Does dataset has time attributes?</strong></h3>
 
             <div class="btn-group">
                 <label class="btn btn-success" ng-model="layer.configuration_options.configureTime" uib-btn-radio="true">Yes</label>
@@ -85,7 +82,6 @@
         <wz-step title="Configure time" wz-disabled="{{timeEnabled(true)}}">
             <h3><strong>Configure your time attributes:</strong></h3>
             <form name="importOptionsForm" class="form-horizontal import-options-form">
-                <p>All datasets uploaded to MapStory must contain time information. If the dataset contains only one timeslice, add a column indicating the timeslice. Learn more about Time Attributes.</p>
                     <div class="form-group">
                         <label for="start_date" class="col-sm-4 col-xs-4 col-md-4 control-label">Date field (start date):</label>
                         <select ng-model="layer.configuration_options.start_date" class="col-md-5 col-xs-5 col-sm-5 input-md" id="start_date" ng-required='layer.configuration_options'>
@@ -106,9 +102,8 @@
             </form>
         </wz-step>
         <wz-step title="Permissions" wz-disabled="{{appending(true)}}">
-            <img class="import-wizard-image" ng-src="{{staticUrl}}mapstory/img/edit.png"/>
             <h3><strong>Allow other users to edit this data?</strong></h3>
-            <p>StoryLayers are better when multiple authors work together.  Would you like to enable editing?</p>
+            <p>Would you like to enable editing?</p>
             <div class="btn-group">
                 <label class="btn btn-success"  ng-model='layer.configuration_options.editable' uib-btn-radio="true">Yes</label>
                 <label class="btn" ng-model='layer.configuration_options.editable' uib-btn-radio="false">No</label>
@@ -118,15 +113,15 @@
             </div>
         </wz-step>
         <wz-step title="{{appending() === true ? 'Append' : 'Import'}}">
-            <h3><strong>Ok, we're ready to create the StoryLayer!</strong></h3>
-            <p>Click below to create your StoryLayer</p>
+            <h3><strong>Ok, we're ready to create the layer!</strong></h3>
+            <p ng-hide="success">Click below to import your layer.</p>
             <div>
-                <div class="clrs-green fnt-weight-400" ng-show="success">The import has finished successfully. View the <a href="{{layer.geonode_layer.url}}?showMetadata=true" class="fnt-weight-600" target="_self">StoryLayer</a>.</div>
-                <div class="clrs-red fnt-weight-400" ng-show="errors">StoryLayer creation has failed.  Please adjust your configuration and try again.</div>
+                <div class="clrs-green fnt-weight-400" ng-show="success"> The import has finished successfully. View the <a href="{{layer.geonode_layer.url}}?showMetadata=true" class="fnt-weight-600" target="_self">layer</a>. </div>
+                <div class="clrs-red fnt-weight-400" ng-show="errors">Layer creation has failed.  Please adjust your configuration and try again.</div>
             </div>
             <div class="import-wizard-button">
                 <i class="fa fa-spinner fa-spin fa-3x" ng-show="processing"></i>
-                <button class="btn" ng-show="!processing && !success" type="submit" wz-next value="Continue">Create my StoryLayer <i class="fa fa-arrow-circle-right"></i></button>
+                <button class="btn" ng-show="!processing && !success" type="submit" wz-next value="Continue">Create my layer <i class="fa fa-arrow-circle-right"></i></button>
             </div>
             <div>
                 <ul class="import-wizard-error-list" ng-show="errorMessages">
@@ -140,6 +135,5 @@
 </div>
 <div class="modal-footer">
     <span class="pull-left modal-footer-help">
-        <a href="//help.mapstory.org">Ask for help</a> &#0149; <a href="http://wiki.mapstory.org/wiki/MapStory_Uploader">Example Data</a> &#0149; <a href="//wiki.mapstory.org/wiki/Data_Repositories">Find Data</a></span>
     <button class="btn btn-primary" type="button" ng-click="ok()">Close</button>
 </div>

--- a/osgeo_importer/static/osgeo_importer/partials/uploadWizard.html
+++ b/osgeo_importer/static/osgeo_importer/partials/uploadWizard.html
@@ -64,7 +64,7 @@
             </form>
         </wz-step>
 
-        <wz-step title="Enable Time?" canexit="layer.configuration_options.configureTime || false">
+        <wz-step title="Enable Time?">
             <h3><strong>Does dataset has time attributes?</strong></h3>
 
             <div class="btn-group">

--- a/osgeo_importer/static/osgeo_importer/test/unit/uploadSpec.js
+++ b/osgeo_importer/static/osgeo_importer/test/unit/uploadSpec.js
@@ -2,7 +2,7 @@ describe('Importer', function() {
 
   // You need to load modules that you want to test,
   // it loads only the "ng" module by default.
-  beforeEach(module('mapstory.uploader'));
+  beforeEach(module('osgeoImporter.uploader'));
 
 
   // inject() is used to inject arguments of all given functions

--- a/osgeo_importer/templates/osgeo_importer/uploads-list.html
+++ b/osgeo_importer/templates/osgeo_importer/uploads-list.html
@@ -13,7 +13,7 @@
   <h2 class="page-title">{% trans "Manage your data" %}</h2>
 </div>
 
-<div class="container" ng-app="mapstory.uploader" ng-controller="uploadList">
+<div class="container" ng-app="osgeoImporter.uploader" ng-controller="uploadList">
     <div class="row">
         <div class="col-md-8">
             <div ng-show="loading" style="margin-right: 50%; margin-left: 50%; margin-top: 30px; margin-bottom: 30px">


### PR DESCRIPTION
Ref: https://github.com/locationtech/geogig/issues/9

(see also current PR https://github.com/ProminentEdge/django-osgeo-importer/pull/23, rebased onto that here for the logging...)

I ran into a problem where geogig's (gzip, gzip) encoding was causing trouble here in the GeoServer handler: specifically, [response.json() calls like this one](https://github.com/prominentedge/django-osgeo-importer/blob/master/osgeo_importer/handlers/geoserver/__init__.py#L112) were throwing JSON decode exceptions -- because Requests would decode one layer of gzip, but not both (so .json() was trying to act on gzip'd content). Setting the `identity` accept-encoding header fixes this.