### PR TITLE
let tastypie version be flexible to avoid conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'Framework :: Django',
     ],
     install_requires=[
-        'django-tastypie==0.11.0',
+        'django-tastypie==0.12.2',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Reference previous dupe: https://github.com/ProminentEdge/django-osgeo-importer/pull/20