### PR TITLE
Get database name from settings instead of hardcoding

### DIFF
--- a/osgeo_importer/handlers/__init__.py
+++ b/osgeo_importer/handlers/__init__.py
@@ -78,7 +78,7 @@ class FieldConverterHandler(GetModifiedFieldsMixin, ImportHandlerMixin):
     field_converter = OGRFieldConverter
 
     def convert_field_to_time(self, layer, field):
-        d = db.connections['datastore'].settings_dict
+        d = db.connections[settings.OSGEO_DATASTORE].settings_dict
         connection_string = "PG:dbname='%s' user='%s' password='%s' host='%s' port='%s'" % (d['NAME'], d['USER'],
                                                                                             d['PASSWORD'], d['HOST'],
                                                                                             d['PORT'])

--- a/osgeo_importer/handlers/geonode/__init__.py
+++ b/osgeo_importer/handlers/geonode/__init__.py
@@ -4,6 +4,7 @@ from osgeo_importer.handlers import ImportHandlerMixin
 from osgeo_importer.handlers import ensure_can_run
 from geonode.geoserver.helpers import gs_slurp
 from django.contrib.auth import get_user_model
+from django.conf import settings
 from django import db
 import os
 import re
@@ -27,7 +28,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
                 if feature_type and hasattr(feature_type, 'store'):
                     return feature_type.store.name
 
-        return db.connections['datastore'].settings_dict['NAME']
+        return db.connections[settings.OSGEO_DATASTORE].settings_dict['NAME']
 
     def can_run(self, layer, layer_config, *args, **kwargs):
         """

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -5,6 +5,7 @@ import requests
 
 from decimal import Decimal, InvalidOperation
 from django import db
+from django.conf import settings
 from osgeo_importer.handlers import ImportHandlerMixin, GetModifiedFieldsMixin, ensure_can_run
 from geoserver.catalog import FailedRequestError
 from geonode.geoserver.helpers import gs_catalog
@@ -79,20 +80,20 @@ class GeoserverPublishHandler(GeoserverHandlerMixin):
         return True
 
     def get_default_store(self):
-        connection = db.connections['datastore']
-        settings = connection.settings_dict
+        connection = db.connections[settings.OSGEO_DATASTORE]
+        db_settings = connection.settings_dict
 
         return {
-              'database': settings['NAME'],
-              'passwd': settings['PASSWORD'],
+              'database': db_settings['NAME'],
+              'passwd': db_settings['PASSWORD'],
               'namespace': 'http://www.geonode.org/',
               'type': 'PostGIS',
               'dbtype': 'postgis',
-              'host': settings['HOST'],
-              'user': settings['USER'],
-              'port': settings['PORT'],
+              'host': db_settings['HOST'],
+              'user': db_settings['USER'],
+              'port': db_settings['PORT'],
               'enabled': 'True',
-              'name': settings['NAME']}
+              'name': db_settings['NAME']}
 
     def get_or_create_datastore(self, layer_config):
         connection_string = layer_config.get('geoserver_store', self.get_default_store())

--- a/osgeo_importer/inspectors.py
+++ b/osgeo_importer/inspectors.py
@@ -309,7 +309,6 @@ class BigDateOGRFieldConverter(OGRInspector):
 
         target_layer.CreateField(ogr.FieldDefn(xd_col, ogr.OFTInteger64))
         xd_col_index = target_layer.GetLayerDefn().GetFieldIndex(xd_col)
-
         target_layer.CreateField(ogr.FieldDefn(parsed_col, ogr.OFTString))
         parsed_col_index = target_layer.GetLayerDefn().GetFieldIndex(parsed_col)
 
@@ -330,7 +329,7 @@ class BigDateOGRFieldConverter(OGRInspector):
 
             # prevent segfaults
             feat = None
-        conn = db.connections['datastore']
+        conn = db.connections[settings.OSGEO_DATASTORE]
         cursor = conn.cursor()
         query = """
         DO $$

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -302,7 +302,7 @@ def raster_import(infile, outfile, *args, **kwargs):
 
 
 def quote_ident(str):
-    conn = db.connections['datastore']
+    conn = db.connections[settings.OSGEO_DATASTORE]
     cursor = conn.cursor()
     query = "SELECT quote_ident(%s);"
     cursor.execute(query, (str,))

--- a/osgeo_importer_prj/settings.py
+++ b/osgeo_importer_prj/settings.py
@@ -78,5 +78,6 @@ DATABASES = {
      }
 }
 
+OSGEO_DATASTORE = 'datastore'
 OSGEO_IMPORTER_GEONODE_ENABLED = True
 LOGGING['loggers']['osgeo_importer'] = {"handlers": ["console"], "level": "DEBUG"}


### PR DESCRIPTION
Instead of hardcoding the database name 'datastore', allow the name to be specified in settings along with the rest of the db config.

Ref: https://github.com/ProminentEdge/django-osgeo-importer/issues/12