### PR TITLE
fix for GeoTIFF imports

### DIFF
--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -29,7 +29,8 @@ class Import(object):
     enabled_handlers = IMPORT_HANDLERS
     source_inspectors = []
     target_inspectors = []
-    valid_extensions = ['gpx', 'geojson', 'json', 'zip', 'tar', 'kml', 'csv', 'shp']
+    valid_extensions = ['gpx', 'geojson', 'json', 'zip', 'tar', 'kml', 'csv',
+                        'shp', 'tif']
 
     def filter_handler_results(self, handler_name):
         """

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -43,7 +43,8 @@ from .utils import sizeof_fmt, load_handler
 
 DEFAULT_LAYER_CONFIGURATION = {'configureTime': False,
                                'editable': True,
-                               'convert_to_date': []}
+                               'convert_to_date': [],
+                               'index': 0}
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +185,7 @@ class UploadLayer(models.Model):
     upload = models.ForeignKey(UploadedData, null=True, blank=True)
     index = models.IntegerField(default=0)
     name = models.CharField(max_length=64, null=True)
-    fields = JSONField(null=True)
+    fields = JSONField(null=True, default={})
     content_type = models.ForeignKey(ContentType, blank=True, null=True)
     object_id = models.PositiveIntegerField(blank=True, null=True)
     layer = GenericForeignKey('content_type', 'object_id')

--- a/osgeo_importer/static/osgeo_importer/importer.js
+++ b/osgeo_importer/static/osgeo_importer/importer.js
@@ -33,7 +33,7 @@
       layer.configuration_options = layer.configuration_options || {};
 
       if (!layer.hasOwnProperty('index') === true) {
-          layer['index'] = index;
+          layer['index'] = 0;
       }
 
       var checkStartDate = layer.configuration_options.hasOwnProperty('start_date') && layer.configuration_options.start_date != "";
@@ -432,7 +432,7 @@
                   layer.configuration_options = layer.configuration_options || {};
 
                   if (!layer.hasOwnProperty('index') === true) {
-                      layer['index'] = index;
+                      layer['index'] = 0;
                   }
 
                   var checkStartDate = layer.configuration_options.hasOwnProperty('start_date') && layer.configuration_options.start_date != "";

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from django.http import HttpResponse
 from django.views.generic import FormView, ListView, TemplateView
 from django.core.urlresolvers import reverse_lazy
@@ -11,6 +12,7 @@ from .utils import import_string
 OSGEO_INSPECTOR = import_string(OSGEO_INSPECTOR)
 OSGEO_IMPORTER = import_string(OSGEO_IMPORTER)
 
+logger = logging.getLogger(__name__)
 
 class JSONResponseMixin(object):
     """
@@ -86,6 +88,11 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
         upload.save()
 
         description = self.get_fields(upload_file.file.path)
+        if not description:
+            logger.debug("No layers detected; assuming raster")
+            configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()
+            upload.uploadlayer_set.add(UploadLayer(name=upload.name,
+                                                   configuration_options=configuration_options))
 
         for layer in description:
             configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -14,6 +14,7 @@ OSGEO_IMPORTER = import_string(OSGEO_IMPORTER)
 
 logger = logging.getLogger(__name__)
 
+
 class JSONResponseMixin(object):
     """
     A mixin that can be used to render a JSON response.


### PR DESCRIPTION
I initially went down a different rabbithole on this before backing out and just fixing FileAddView. This works assuming we're fine with rasters being imported as UploadLayer objects (with null/default layer-like attributes, i.e., fields & feature count). Otherwise we could e.g., build a separate import pipeline for UploadedData.

Added test coverage coming later, once I figure out why tests are failing against master...