### PR TITLE
add geopackage and wfs support to gdal

### DIFF
--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -136,6 +136,12 @@ class UploaderTests(DjagnoOsgeoMixin):
 
         return layer
 
+    def test_geopackage_gdal_support(self):
+        f = 'boxes_plus_raster.gpkg'
+        filename = os.path.join(os.path.dirname(__file__), '..', 'importer-test-files', f)
+        l = gdal.OpenEx(filename)
+        self.assertTrue(l.GetDriver().ShortName, 'GPKG')
+
     def generic_raster_import(self, file, configuration_options=[{'index': 0}]):
         f = file
         filename = os.path.join(os.path.dirname(__file__), '..', 'importer-test-files', f)

--- a/scripts/build_gdal.sh
+++ b/scripts/build_gdal.sh
@@ -8,12 +8,14 @@ cd geos-3.4.2
 sudo make -j 4
 sudo make install
 
+sudo mkdir -p /srv/gdal
+sudo chown vagrant:vagrant /srv/gdal
 git clone https://github.com/OSGeo/gdal.git /srv/gdal
 cd /srv/gdal/gdal
-./configure --with-python
-./mkbindist.sh -dev $version linux
+./configure --with-python --with-sqlite3 --with-spatialite --with-geopackage --with-curl
+#./mkbindist.sh -dev $version linux
 sed -i 's/#!\/bin\/sh/#!\/bin\/bash/'  mkbindist.sh
-version=$(<VERSION)
+version=$(cat VERSION)
 ./mkbindist.sh -dev $version linux
 cp gdal-${version}-linux-bin.tar.gz /vagrant
 # aws s3 cp gdal-2.1.0-linux-bin.tar.gz s3://django-osgeo-importer --profile=prominentedge

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,9 +15,9 @@ sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y # For postgresql-9.1
 sudo rm -f /etc/apt/sources.list.d/pgdg-source.list # postgis from pgdg requires different gdal package than the grass package
 sudo apt-get update -qq
 
-wget https://s3.amazonaws.com/django-osgeo-importer/gdal-2.1.0-linux-bin.tar.gz
-sudo tar --directory=/usr/local/lib -xvf gdal-2.1.0-linux-bin.tar.gz
-sudo mv /usr/local/lib/gdal-2.1.0-linux-bin /usr/local/lib/gdal
+wget https://s3.amazonaws.com/django-osgeo-importer/gdal-2.2.0-linux-bin.tar.gz
+sudo tar --directory=/usr/local/lib -xvf gdal-2.2.0-linux-bin.tar.gz
+sudo mv /usr/local/lib/gdal-2.2.0-linux-bin /usr/local/lib/gdal
 export PATH=/usr/local/lib/gdal/bin:$PATH
 sudo touch /usr/lib/python2.7/dist-packages/gdal.pth
 sudo su -c  "echo '/usr/local/lib/gdal/lib/python2.7/site-packages' > /usr/lib/python2.7/dist-packages/gdal.pth"
@@ -31,7 +31,10 @@ sudo apt-get remove -y postgresql-9.3-postgis-2.1 # Remove postgis from pgdg, wi
 sudo apt-get install -y --no-install-recommends postgresql-9.3-postgis-2.1 libpq-dev python-dev python-lxml libxslt1-dev
 sudo apt-get install -y python-virtualenv python-imaging python-pyproj python-shapely python-nose python-httplib2 python-httplib2 gettext git
 sudo apt-get install -y libproj0 libproj-dev postgresql-plpython-9.3 python-numpy python-dateutil libjpeg62 libjpeg-dev zlib1g-dev python-dev libxml2 libxml2-dev libxslt1-dev libpq-dev postgis
-
+#install libraries for a stacked out gdal
+sudo apt-get install -y sqlite3 libsqlite3-0 libsqlite3-dev libspatialite5 libspatialite-dev libcurl4-gnutls-dev libxerces-c-dev libxml2-dev 
+sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-dev libpq-dev libpng12-dev libjpeg-dev libgif-dev liblzma-dev
+sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
 
 # python


### PR DESCRIPTION
Adds support for additional file formats to the vagrant build for Geopackage and WFS.