### PR TITLE
make package installs include essential templates and static files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,12 @@ setup(
     package_data = {
         'osgeo_importer': [
             'locale/*/LC_MESSAGES/*',
+            'templates/osgeo_importer/*',
+            'static/osgeo_importer/*',
+            'static/osgeo_importer/css/*',
+            'static/osgeo_importer/img/*',
+            'static/osgeo_importer/js/*',
+            'static/osgeo_importer/partials/*',
         ],
     },
     license='BSD',


### PR DESCRIPTION
Without this I was finding that a `pip install` of django-osgeo-importer was yielding a version which
didn't quite work (Django tracebacks due to django-osgeo-importer templates unexpectedly missing, and 404s and frontend issues due to static files not being served).

To test for this kind of thing, you may have to do a `pip install` without `-e`, or it will implicitly pick up a bunch of files in the directory that `pip install -e` is pointed to, but which are not collected via the MANIFEST mechanism used by clean pip installs.