### PR TITLE
fix assertion against layer attributes

### DIFF
--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -144,7 +144,12 @@ class UploaderTests(DjagnoOsgeoMixin):
                     self.assertTrue(layer.attributes.count() >= DataSource(filename)[0].num_fields)
 
                 # make sure we have at least one dateTime attribute
-                self.assertTrue('xsd:dateTime' or 'xsd:date' in [n.attribute_type for n in layer.attributes.all()])
+                date_attrs = [u'xsd:dateTime', u'xsd:date']
+                attr_types = [n.attribute_type for n in layer.attributes.all()]
+                self.assertTrue(
+                    any(date_attr in attr_types for date_attr in date_attrs),
+                    msg="no date attribute found in {0!r}".format(attr_types)
+                )
                 layer_results.append(layer)
 
         return layer_results[0]


### PR DESCRIPTION
This assertion was always succeeding because the value of the Python expression `('xsd:dateTime' or ...)` is always `'xsd:dateTime'`, which is truthy, so that `assertTrue` passes regardless of what is happening. One could guess this wouldn't be intended, but the comment `make sure we have at least one dateTime attribute` makes the original intention very clear.

To complicate matters, it looks like there were several tests which should have been failing before, and now are failing because this assertion has been fixed, which will cause any future PRs to fail the tests. It would help me if someone more familiar with the date requirement could fix these test failures so that the test suite can be used to validate future PRs that are in the works.

Please don't hesitate to tell me if there are any adjustments you would like to have made to this PR.