### PR TITLE
remove unused assertion

### DIFF
--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -143,13 +143,6 @@ class UploaderTests(DjagnoOsgeoMixin):
                 if not filename.endswith('zip'):
                     self.assertTrue(layer.attributes.count() >= DataSource(filename)[0].num_fields)
 
-                # make sure we have at least one dateTime attribute
-                date_attrs = [u'xsd:dateTime', u'xsd:date']
-                attr_types = [n.attribute_type for n in layer.attributes.all()]
-                self.assertTrue(
-                    any(date_attr in attr_types for date_attr in date_attrs),
-                    msg="no date attribute found in {0!r}".format(attr_types)
-                )
                 layer_results.append(layer)
 
         return layer_results[0]


### PR DESCRIPTION
Per @sarasafavi on #37, several of the test datasets do not contain any dateTime or date attributes, and this is a legacy requirement anyway. In light of this, it appears that the test failures this assertion is causing are spurious, so that it would be better to remove it in order to allow future PRs to be tested accurately on the CI