### PR TITLE
add spaces around shell operator -f and its argument

### DIFF
--- a/scripts/before_script.sh
+++ b/scripts/before_script.sh
@@ -11,7 +11,7 @@ if [ -n "$1" ]
 fi
 
 
-if [-f "/vagrant/src/geonode/geonode/development.db"]
+if [ -f "/vagrant/src/geonode/geonode/development.db" ]
  then
  rm /vagrant/src/geonode/geonode/development.db
 fi


### PR DESCRIPTION
this was leading to an error during vagrant provision:
`/tmp/vagrant-shell: line 14: [-f: command not found`