### PR TITLE
don't require numpy to run, unless using timeparse

### DIFF
--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -1,6 +1,5 @@
 import gdal
 import logging
-import numpy
 import ogr
 import osr
 import os
@@ -45,6 +44,7 @@ GDAL_GEOMETRY_TYPES = {
 
 
 def timeparse(timestr):
+    import numpy
     DEFAULT = datetime(1, 1, 1)
     bc = False
     if re.search(r'bce?', timestr, flags=re.I):


### PR DESCRIPTION
Right now, every user of this django app must have `numpy` installed. But `numpy` is currently only being used in `utils.timeparse`. `utils.timeparse` is only being used by `BigDateOGRFieldConverter`, which is only used by `handlers.BigDateFieldConverterHandler`. 

The docstring for that class states that using it requires a special build of GeoTools. Unless that special build is a requirement of django-osgeo-importer, any installation without it will already be unable to use `BigDateFieldConverterHandler`, which is the only user of `numpy`.

Deferring this import allows individual installations to either use or not use numpy depending on whether they also have the right GeoTools setup and intend to use `BigDateOGRFieldConverter`.