### PR TITLE
replace import * with named imports where feasible

### DIFF
--- a/osgeo_importer/geonode_apis.py
+++ b/osgeo_importer/geonode_apis.py
@@ -1,5 +1,12 @@
 import os
-from .api import *  # noqa
+from .api import (  # noqa: F401
+    UserResource,
+    UploadedLayerResource,
+    UserOwnsObjectAuthorization,
+    UploadedDataResource,
+    MultipartResource,
+    UploadedFileResource
+)
 from geonode.api.api import ProfileResource
 from geonode.geoserver.helpers import ogc_server_settings
 from tastypie.fields import ForeignKey

--- a/osgeo_importer_prj/urls.py
+++ b/osgeo_importer_prj/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
 from osgeo_importer.urls import urlpatterns as importer_urlpatterns
 
-from geonode.urls import *
+from geonode.urls import urlpatterns
 
 urlpatterns = patterns('',
    url(r'^/?$',


### PR DESCRIPTION
I couldn't exterminate all instances of import * because outside of the files changed here, there are way too many GeoNode settings and too much change in them to make it convenient to always import them all explicitly, which is why that instance in _prj is left behind (but shouldn't matter a lot anyway because of what _prj is for).

Although it is arguably a necessary evil in django settings files, here is what [PEP 8 ](http://legacy.python.org/dev/peps/pep-0008/)says about `import *`: 

> Wildcard imports (from <module> import *) should be avoided, as they make it unclear which names are present in the namespace, confusing both readers and many automated tools. There is one defensible use case for a wildcard import, which is to republish an internal interface as part of a public API (for example, overwriting a pure Python implementation of an interface with the definitions from an optional accelerator module and exactly which definitions will be overwritten isn't known in advance).